### PR TITLE
Fix gps

### DIFF
--- a/customization/includes.chroot/etc/jaiabot/init/first-boot.sh
+++ b/customization/includes.chroot/etc/jaiabot/init/first-boot.sh
@@ -114,6 +114,7 @@ echo "###############################################"
 
 # for backwards compatibility, remove once we've updated all bots to rootfs-gen filesystem
 mkdir -p /etc/jaiabot/dev
+systemctl enable gps_i2c_pty
 ln -s -f /dev/gps0 /etc/jaiabot/dev/gps
 ln -s -f /dev/arduino /etc/jaiabot/dev/arduino
 ln -s -f /dev/xbee /etc/jaiabot/dev/xbee

--- a/customization/includes.chroot/etc/ntp.conf
+++ b/customization/includes.chroot/etc/ntp.conf
@@ -29,8 +29,9 @@ pool ntp.ubuntu.com
 # GPS Serial data reference (JSON API to GPSD)
 # corresponds to /dev/gps0 - see https://www.eecis.udel.edu/~mills/ntp/html/drivers/driver46.html
 server 127.127.46.0 minpoll 4 maxpoll 4 prefer
-# time1 uncalibrated
-fudge 127.127.46.0 time1 0.0 flag1 1 refid GPS
+# time1 uncalibrated (no PPS), time2 roughly calibrated in-situ
+# using the standard ubuntu.pool.ntp.org servers
+fudge 127.127.46.0 time1 0.0 time2 0.06 flag1 1 refid GPS
 
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
 # details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>

--- a/customization/includes.chroot/etc/systemd/system/gps_i2c_pty.service
+++ b/customization/includes.chroot/etc/systemd/system/gps_i2c_pty.service
@@ -1,13 +1,13 @@
 [Unit]
-Description=Script to pipe GPS data from I2C to a fifo
+Description=Script to read GPS data from I2C to a pty
 After=network.target
 StartLimitIntervalSec=0
 
 [Service]
-Type=simple
+Type=notify
 Restart=never
 User=root
-ExecStart=/usr/bin/gps-i2c-pipe.py /dev/gps0
+ExecStart=/usr/bin/gps-i2c-pty.py /dev/gps0
 
 [Install]
 RequiredBy=gpsd.target

--- a/customization/includes.chroot/etc/systemd/system/gps_i2c_pty.service
+++ b/customization/includes.chroot/etc/systemd/system/gps_i2c_pty.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Script to read GPS data from I2C to a pty
+Before=ntp.service
+Before=gpsd.service
 After=network.target
-StartLimitIntervalSec=0
 
 [Service]
 Type=notify
-Restart=never
 User=root
 ExecStart=/usr/bin/gps-i2c-pty.py /dev/gps0
 
 [Install]
-RequiredBy=gpsd.target
+RequiredBy=gpsd.service

--- a/customization/package-lists/jaiabot.list.chroot
+++ b/customization/package-lists/jaiabot.list.chroot
@@ -13,3 +13,4 @@ gpsd
 wireguard
 ntp
 ntpstat
+python3-systemd


### PR DESCRIPTION
Switch to pty from fifo for python i2c gps reader script as [NTP refclock 46](https://www.eecis.udel.edu/~mills/ntp/html/drivers/driver46.html) checks to make sure /dev/gps0 is a character device before starting (even though GPSD is ok with the fifo and otherwise refclock 46 reads only from GPSD as far as I know).

Also, add a systemd notify to the script to ensure the service doesn't count as "started" before the pty and symlink (normally /dev/gps0) is created.

Update service file to correctly start before ntp and gpsd, which should hopefully eliminate race conditions with getting data to ntp and goby_gps, such as https://trello.com/c/4fVBnpkb/480-jaiabotgobygps-requires-a-restart-when-first-powered-on-before-displaying-gps-locations-despite-cgps-showing-gps-data)

Rename both service and script to `*pty*` rather than `*pipe*` to reflect new functionality.