### PR TITLE
bug-wlan0-not-connecting

### DIFF
--- a/customization/package-lists/tools.list.chroot
+++ b/customization/package-lists/tools.list.chroot
@@ -18,5 +18,8 @@ xz-utils
 ## for stress testing
 stress
 memtester
-cockpit
-
+#Removing cockpit for now
+#Wlan0 no longer connects to router in
+#the current configuration when this
+#is installed
+#cockpit


### PR DESCRIPTION
Removing cockpit because we can no longer connect to router using wlan0 in the current configuration