### PR TITLE
Add cockpit without network-manager

### DIFF
--- a/customization/hooks/11-install-cockpit-no-networkmanager.chroot
+++ b/customization/hooks/11-install-cockpit-no-networkmanager.chroot
@@ -1,0 +1,6 @@
+#!/bin/sh  
+
+echo "Install Cockpit without NetworkManager"
+
+# network manager messes up wlan0 (plus we don't want it)
+apt-get install -y --no-install-recommends cockpit cockpit-dashboard cockpit-packagekit cockpit-storaged

--- a/customization/package-lists/tools.list.chroot
+++ b/customization/package-lists/tools.list.chroot
@@ -18,8 +18,3 @@ xz-utils
 ## for stress testing
 stress
 memtester
-#Removing cockpit for now
-#Wlan0 no longer connects to router in
-#the current configuration when this
-#is installed
-#cockpit


### PR DESCRIPTION
This avoids messing up networking (specifically wpa_supplicant / wlan0)