### PR TITLE
task-update-embedded-source-to-release

### DIFF
--- a/customization/archives/jaiabot.list.chroot
+++ b/customization/archives/jaiabot.list.chroot
@@ -1,1 +1,3 @@
-deb http://packages.jaia.tech/ubuntu/continuous/1.y/ @DISTRIBUTION@/
+#deb http://packages.jaia.tech/ubuntu/continuous/1.y/ @DISTRIBUTION@/
+#deb http://packages.jaia.tech/ubuntu/beta/1.y/ @DISTRIBUTION@/
+deb http://packages.jaia.tech/ubuntu/release/1.y/ @DISTRIBUTION@/

--- a/customization/includes.chroot/etc/dhcp/dhclient.conf
+++ b/customization/includes.chroot/etc/dhcp/dhclient.conf
@@ -1,0 +1,55 @@
+# Configuration file for /sbin/dhclient.
+#
+# This is a sample configuration file for dhclient. See dhclient.conf's
+#       man page for more information about the syntax of this file
+#       and a more comprehensive list of the parameters understood by
+#       dhclient.
+#
+# Normally, if the DHCP server provides reasonable information and does
+#       not leave anything out (like the domain name, for example), then
+#       few changes must be made to this file, if any.
+#
+
+option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
+
+send host-name = gethostname();
+request subnet-mask, broadcast-address, time-offset, routers,
+        domain-name, domain-name-servers, domain-search, host-name,
+        dhcp6.name-servers, dhcp6.domain-search, dhcp6.fqdn, dhcp6.sntp-servers,
+        netbios-name-servers, netbios-scope, interface-mtu,
+        rfc3442-classless-static-routes, ntp-servers;
+
+#send dhcp-client-identifier 1:0:a0:24:ab:fb:9c;
+#send dhcp-lease-time 3600;
+#supersede domain-name "fugue.com home.vix.com";
+#prepend domain-name-servers 127.0.0.1;
+#require subnet-mask, domain-name-servers;
+timeout 1;
+#retry 60;
+#reboot 10;
+#select-timeout 5;
+#initial-interval 2;
+#script "/sbin/dhclient-script";
+#media "-link0 -link1 -link2", "link0 link1";
+#reject 192.33.137.209;
+
+#alias {
+#  interface "eth0";
+#  fixed-address 192.5.5.213;
+#  option subnet-mask 255.255.255.255;
+#}
+
+#lease {
+#  interface "eth0";
+#  fixed-address 192.33.137.200;
+#  medium "link0 link1";
+#  option host-name "andare.swiftmedia.com";
+#  option subnet-mask 255.255.255.0;
+#  option broadcast-address 192.33.137.255;
+#  option routers 192.33.137.250;
+#  option domain-name-servers 127.0.0.1;
+#  renew 2 2000/1/12 00:00:01;
+#  rebind 2 2000/1/12 00:00:01;
+#  expire 2 2000/1/12 00:00:01;
+#}
+


### PR DESCRIPTION
We should use release by default for jaiabot-embedded and added dhcp config so we do not have to do this at first boot