### PR TITLE
URGENT: Remove cockpit - again!!

### DIFF
--- a/customization/package-lists/tools.list.chroot
+++ b/customization/package-lists/tools.list.chroot
@@ -18,5 +18,3 @@ xz-utils
 ## for stress testing
 stress
 memtester
-cockpit
-


### PR DESCRIPTION
Breaks wifi (see original PR: https://github.com/jaiarobotics/jaiabot-rootfs-gen/pull/22)

Still installed without network manager using jaiabot-rootfs-gen/customization/hooks/11-install-cockpit-no-networkmanager.chroot.

From Slack:
> Ok, so regarding the wifi issue - this is a regression (same bug as before) based on the fact that cockpit has gotten back into the tool.list.chroot. What I'm confused about is how this happened. I'm not used to working on projects that squash merge so that might be part of the issue. Either way, it got re-introduced here: https://github.com/jaiarobotics/jaiabot-rootfs-gen/pull/29/files#diff-1668a10c5b422883d575ac694d44b5c006225b734937f77b2f7470e0b2e61deaR21
The blame shows I added that commit, last September 19, 2022: https://github.com/jaiarobotics/jaiabot-rootfs-gen/blame/426018fb3e2828ddf0fcf9a0788f76b0b4ee3eaa/customization/package-lists/tools.list.chroot#L21
But was removed later on September 26, 2022: https://github.com/jaiarobotics/jaiabot-rootfs-gen/pull/22/files
Anyone who is more familiar with squashing merges know how this might have happened?