### PR TITLE
task-remove-enable-gps-i2c

### DIFF
--- a/customization/includes.chroot/etc/jaiabot/init/first-boot.sh
+++ b/customization/includes.chroot/etc/jaiabot/init/first-boot.sh
@@ -138,7 +138,6 @@ echo "###############################################"
 
 # for backwards compatibility, remove once we've updated all bots to rootfs-gen filesystem
 mkdir -p /etc/jaiabot/dev
-systemctl enable gps_i2c_pty
 ln -s -f /dev/gps0 /etc/jaiabot/dev/gps
 ln -s -f /dev/arduino /etc/jaiabot/dev/arduino
 ln -s -f /dev/xbee /etc/jaiabot/dev/xbee

--- a/customization/includes.chroot/etc/udev/rules.d/90-jaiabot_serial.rules
+++ b/customization/includes.chroot/etc/udev/rules.d/90-jaiabot_serial.rules
@@ -4,4 +4,3 @@ KERNEL=="ttyUSB0", SYMLINK+="arduino"
 ## xbee
 KERNEL=="ttyAMA2", SYMLINK+="xbee"
 
-## gps - managed by gps_i2c_pty.service


### PR DESCRIPTION
Removing the enable gps i2c because we removed it out of rootfs-gen