### PR TITLE
Add Ubuntu 22.04 Image builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,8 +3,10 @@ workflows:
   version: 2
   commit:
     jobs:
-      - raspi-image-create      
-      - virtualbox-image-create
+      - raspi-image-create-focal
+      - virtualbox-image-create-focal
+      - raspi-image-create-jammy
+      - virtualbox-image-create-jammy
   nightly:
     triggers:
       - schedule:
@@ -12,59 +14,93 @@ workflows:
           filters:
             branches:
               only:
-                - /.*/
+                - master
     jobs:
-      - raspi-image-create
-      - virtualbox-image-create
+      - raspi-image-create-focal
+      - virtualbox-image-create-focal
+      - raspi-image-create-jammy
+      - virtualbox-image-create-jammy
 
 jobs:
-  raspi-image-create:
+  raspi-image-create-focal:
     machine:
       image: ubuntu-2004:current
     resource_class: arm.medium
+    environment:
+      DISTRO_RELEASE_CODENAME: "focal"
     steps:
       - checkout
-      - run:
+      - run: &run-install-apt-raspi
           name: Install apt dependencies
           command: sudo apt-get update && sudo apt-get -y install pigz dosfstools gcc-aarch64-linux-gnu git kpartx live-build sudo wget
-      - run:
+      - run: &run-create-sd-raspi
           name: Create base SD card image for Raspberry Pi
           command: >-
             mkdir images &&
-            sudo scripts/create_raspi_base_image.sh --dest images/base_image.img --native
-      - run:
+            sudo scripts/create_raspi_base_image.sh --dest images/base_image.img --native --distribution ${DISTRO_RELEASE_CODENAME}
+      - run: &run-rename-image-raspi
           name: Rename image
           command: >-
             CIRCLE_BRANCH_ESC=$(echo "$CIRCLE_BRANCH" | tr '/' '_')
             ROOTFS_BUILD_TAG="$(git describe --tags HEAD | sed 's/_/~/' | sed 's/-/+/g')" &&          
             mv images/base_image.img \
-               images/jaiabot_"$CIRCLE_BRANCH_ESC"_img-"$ROOTFS_BUILD_TAG".img
-      - run:
+               images/jaiabot_"$DISTRO_RELEASE_CODENAME"_"$CIRCLE_BRANCH_ESC"_img-"$ROOTFS_BUILD_TAG".img
+      - run: &run-compress-image-raspi
           name: Compress image
           command: pigz images/*.img
-      - store_artifacts:
+      - store_artifacts: &store-raspi
           path: images/
-  virtualbox-image-create:
+  virtualbox-image-create-focal:
     machine:
       image: ubuntu-2004:current
     resource_class: medium
+    environment:
+      DISTRO_RELEASE_CODENAME: "focal"
     steps:
       - checkout
-      - run:
+      - run: &run-install-apt-vbox
           name: Install apt dependencies
           command: sudo apt-get update && sudo apt-get -y install pigz dosfstools gcc-aarch64-linux-gnu git kpartx live-build sudo wget virtualbox
-      - run:
+      - run: &run-create-sd-vbox
           name: Create base SD card image for VirtualBox
           command: >-
             CIRCLE_BRANCH_ESC=$(echo "$CIRCLE_BRANCH" | tr '/' '_')
             mkdir images &&
             ROOTFS_BUILD_TAG="$(git describe --tags HEAD | sed 's/_/~/' | sed 's/-/+/g')" &&          
-            sudo scripts/create_raspi_base_image.sh --dest images/jaiabot_"$CIRCLE_BRANCH_ESC"_img-"$ROOTFS_BUILD_TAG".img --virtualbox
-      - run:
+            sudo scripts/create_raspi_base_image.sh --dest images/jaiabot_"$DISTRO_RELEASE_CODENAME"_"$CIRCLE_BRANCH_ESC"_img-"$ROOTFS_BUILD_TAG".img --virtualbox --distribution ${DISTRO_RELEASE_CODENAME}
+      - run: &run-rename-image-vbox
           name: Move image for storage
           command: >-
             mkdir vbox &&
             sudo chmod a+rwx images/*.ova &&
             mv images/*.ova vbox/
-      - store_artifacts:
+      - store_artifacts: &store-vbox
           path: vbox/
+
+  raspi-image-create-jammy:
+    machine:
+      image: ubuntu-2204:current
+    resource_class: arm.medium
+    environment:
+      DISTRO_RELEASE_CODENAME: "jammy"
+    steps:
+      - checkout
+      - run: *run-install-apt-raspi
+      - run: *run-create-sd-raspi
+      - run: *run-rename-image-raspi
+      - run: *run-compress-image-raspi
+      - store_artifacts: *store-raspi
+  virtualbox-image-create-jammy:
+    machine:
+      image: ubuntu-2204:current
+    resource_class: medium
+    environment:
+      DISTRO_RELEASE_CODENAME: "jammy"
+    steps:
+      - checkout
+      - run: *run-install-apt-vbox
+      - run: *run-create-sd-vbox
+      - run: *run-rename-image-vbox
+      - store_artifacts: *store-vbox
+
+          

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
     resource_class: arm.medium
     environment:
       DISTRO_RELEASE_CODENAME: "focal"
+      DEBIAN_FRONTEND: "noninteractive"
     steps:
       - checkout
       - run: &run-install-apt-raspi
@@ -56,6 +57,7 @@ jobs:
     resource_class: medium
     environment:
       DISTRO_RELEASE_CODENAME: "focal"
+      DEBIAN_FRONTEND: "noninteractive"
     steps:
       - checkout
       - run: &run-install-apt-vbox
@@ -83,6 +85,7 @@ jobs:
     resource_class: arm.medium
     environment:
       DISTRO_RELEASE_CODENAME: "jammy"
+      DEBIAN_FRONTEND: "noninteractive"
     steps:
       - checkout
       - run: *run-install-apt-raspi
@@ -96,6 +99,7 @@ jobs:
     resource_class: medium
     environment:
       DISTRO_RELEASE_CODENAME: "jammy"
+      DEBIAN_FRONTEND: "noninteractive"
     steps:
       - checkout
       - run: *run-install-apt-vbox

--- a/auto/config.native
+++ b/auto/config.native
@@ -5,7 +5,7 @@ export LB_BOOTSTRAP_FLAVOUR="minbase"
 lb config noauto \
  --apt-indices none \
  --architectures arm64 \
- --archive-areas 'main universe multiverse' \
+ --archive-areas 'main universe multiverse restricted' \
  --binary-filesystem ext4 \
  --binary-images tar \
  --chroot-filesystem none \

--- a/auto/config.qemu
+++ b/auto/config.qemu
@@ -5,7 +5,7 @@ export LB_BOOTSTRAP_FLAVOUR="minbase"
 lb config noauto \
  --apt-indices none \
  --architectures arm64 \
- --archive-areas 'main universe multiverse' \
+ --archive-areas 'main universe multiverse restricted' \
  --binary-filesystem ext4 \
  --binary-images tar \
  --bootstrap-qemu-arch arm64 \

--- a/auto/config.virtualbox
+++ b/auto/config.virtualbox
@@ -6,7 +6,7 @@ export LB_BOOTSTRAP_FLAVOUR="minbase"
 lb config noauto \
  --apt-indices none \
  --architectures amd64 \
- --archive-areas 'main universe multiverse' \
+ --archive-areas 'main universe multiverse restricted' \
  --binary-filesystem ext4 \
  --binary-images tar \
  --bootloader grub2 \

--- a/customization/hooks/11-install-cockpit-no-networkmanager.chroot
+++ b/customization/hooks/11-install-cockpit-no-networkmanager.chroot
@@ -1,6 +1,0 @@
-#!/bin/sh  
-
-echo "Install Cockpit without NetworkManager"
-
-# network manager messes up wlan0 (plus we don't want it)
-apt-get install -y --no-install-recommends cockpit cockpit-dashboard cockpit-packagekit cockpit-storaged

--- a/customization/package-lists/raspi.list.chroot
+++ b/customization/package-lists/raspi.list.chroot
@@ -1,3 +1,8 @@
 # linux-image-raspi
 flash-kernel
+
+#if DISTRIBUTION focal
 linux-firmware-raspi2
+#else
+linux-firmware-raspi
+#endif

--- a/customization/package-lists/raspi.list.chroot
+++ b/customization/package-lists/raspi.list.chroot
@@ -3,6 +3,8 @@ flash-kernel
 
 #if DISTRIBUTION focal
 linux-firmware-raspi2
-#else
+#endif
+
+#if DISTRIBUTION jammy
 linux-firmware-raspi
 #endif

--- a/scripts/create_raspi_base_image.sh
+++ b/scripts/create_raspi_base_image.sh
@@ -49,6 +49,9 @@
 #     --virtualbox
 #         Create an amd64 virtualbox VDI, rather than a Raspi SD card image (but otherwise create a very similar image)
 #
+#     --distribution
+#         Desired Ubuntu distribution codename (e.g., "focal" or "jammy")
+#
 # This script is invoked by the raspi-image-master job in the cgsn_mooring
 # project's CircleCI but can also be invoked directly.
 #
@@ -72,6 +75,7 @@ ROOTFS_BUILD_PATH="$TOPLEVEL"
 DEFAULT_IMAGE_NAME=jaiabot_img-"$ROOTFS_BUILD_TAG".img
 OUTPUT_IMAGE_PATH="$(pwd)"/"$DEFAULT_IMAGE_NAME"
 ROOTFS_TARBALL=
+DISTRIBUTION=focal
 
 # Ensure user is root
 if [ "$UID" -ne 0 ]; then
@@ -142,6 +146,10 @@ while [[ $# -gt 0 ]]; do
     ;;
   --virtualbox)
     VIRTUALBOX=1
+    ;;
+  --distribution)
+    DISTRIBUTION="$1"
+    shift
     ;;
   *)
     echo "Unexpected argument: $KEY" >&2
@@ -217,7 +225,8 @@ if [ -z "$ROOTFS_TARBALL" ]; then
     lb clean
     [ -z "$NATIVE" ] && cp auto/config.qemu auto/config || cp auto/config.native auto/config
     [ ! -z "$VIRTUALBOX" ] && cp auto/config.virtualbox auto/config
-    
+
+    sed -i "s/--distribution.*\\\/--distribution ${DISTRIBUTION} \\\/" auto/config
     lb config
     mkdir -p config/includes.chroot/etc/jaiabot
     chmod 775 config/includes.chroot/etc/jaiabot


### PR DESCRIPTION
Add config to build Jammy (Ubuntu 22.04) images.

Also:
- Remove cockpit as it's no longer needed.